### PR TITLE
New API using a standard, fastAPI, and Uvicorn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ venv
 .vscode
 .idea
 .fleet
+
+.DS_Store
+__pycache__
+
+pid
+Pipfile.lock

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,9 @@ gradio = "==3.22.1"
 rich = "*"
 pexpect = "*"
 psutil = "*"
+fastapi = "*"
+uvicorn = "*"
+jinja2 = "*"
 
 [dev-packages]
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Alpaca-Turbo: A Fast and Configurable Language Model-Based Chat UI
+# Alpaca-Turbo: A Fast and Configurable Language Model-Based Chat UI and API
 
 [Discord](https://discord.gg/FEc4sn7U)
 
@@ -31,6 +31,16 @@ cd Alpaca-Turbo
 pip install -r requirements.txt
 python webui.py
 ```
+
+## Using the API
+
+Run using `uvicorn api:app --reload`
+
+This will start a local development server at http://127.0.0.1:8000.
+
+You can access the auto-generated documentation for your API at http://127.0.0.1:8000/docs.
+
+Discussion around standardizing the API can be found [here](https://alexatallah.notion.site/RFC-LLM-API-Standard-c8f15d24bd2f4ab98b656f08cdc1c4fb).
 
 ## Troubleshooting
 

--- a/api.py
+++ b/api.py
@@ -1,31 +1,88 @@
-# importing the multiprocessing module
-# import signal
-import time
-
+import asyncio
+# from async_generator import async_generator, yield_
+from typing import List, Optional, Union
+from pydantic import BaseModel
+from fastapi.responses import StreamingResponse, HTMLResponse
+from fastapi import FastAPI, Body, Request
+from fastapi.templating import Jinja2Templates
 from alpaca_turbo import Assistant
-from flask import Flask, Response, render_template, request
 
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-class-docstring
-# pylint: disable=missing-function-docstring
 
 assistant = Assistant()
 assistant.prep_model()
-app = Flask(__name__)
+
+templates = Jinja2Templates(directory="templates")
 
 
-@app.route("/")
-def index():
-    return render_template("index.html")
+app = FastAPI()
 
 
-@app.route("/ask_bot", methods=["POST"])
-def ask_bot():
-    question = request.json.get("question")
-    print("Question:", question)
+class Attachment(BaseModel):
+    image: bytes
 
-    return Response(assistant.ask_bot(question), mimetype="text/plain")
 
-if __name__ == "__main__":
-    # both processes finished
-    app.run(debug=True)
+# TODO support attachments: Communication = Union[str, Attachment]
+Communication = str
+
+
+class Message(BaseModel):
+    role: str
+    content: Communication
+
+
+class CompletionRequest(BaseModel):
+    model: Optional[str]
+    prompt: Union[Communication, List[Message]]
+    max_tokens: Optional[int]
+    temperature: Optional[float]
+    stop: Optional[Union[str, List[str]]]
+
+
+class CompletionResponseChoice(BaseModel):
+    text: Communication
+    finish_reason: Optional[str]
+
+
+class CompletionResponse(BaseModel):
+    choices: List[CompletionResponseChoice]
+
+
+class Model:
+    def get_completion(self, model, prompt, max_tokens, temperature, stop) -> str:
+        res = ""
+        for char in assistant.ask_bot(prompt):
+            res += char
+        return res
+
+    def get_completion_tokens(self, model, prompt, max_tokens, temperature, stop):
+        for char in assistant.ask_bot(prompt):
+            yield char
+
+
+model = Model()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def read_item(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.post("/completions", response_model=CompletionResponse)
+async def completions(request: CompletionRequest):
+    text = model.get_completion(
+        request.model, request.prompt, request.max_tokens, request.temperature, request.stop)
+    return CompletionResponse(choices=[CompletionResponseChoice(text=text)])
+
+
+@app.post("/streams")
+async def streams(request: CompletionRequest):
+    def completion_token_generator():
+        for token in model.get_completion_tokens(request.model, request.prompt, request.max_tokens, request.temperature, request.stop):
+            completion_response = CompletionResponse(
+                choices=[CompletionResponseChoice(text=token)])
+            yield f"data: {completion_response.json()}\n\n"
+
+    return StreamingResponse(completion_token_generator())
+
+# Run using uvicorn api:app --reload
+# This will start a local development server at http://127.0.0.1:8000. You can access the auto-generated documentation for your API at http://127.0.0.1:8000/docs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-flask
 gradio==3.22.1
 rich
 pexpect
 psutil
+fastapi
+uvicorn
+jinja2

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,8 +27,8 @@
           var question = $('#question').val();
           $.ajax({
             type: 'POST',
-            url: '/ask_bot',
-            data: JSON.stringify({ 'question': question }),
+            url: '/completions',
+            data: JSON.stringify({ 'prompt': question }),
             contentType: 'application/json; charset=utf-8',
             dataType: 'text',
             success: function(data) {


### PR DESCRIPTION
The schema for this API is based on OpenAI's api: https://platform.openai.com/docs/api-reference/completions/create

Standardizing the API allows apps to be built on top of it, already knowing how to talk to Alpaca.

Includes autogenerated docs:
<img width="930" alt="Screenshot 2023-03-24 at 3 31 46 PM" src="https://user-images.githubusercontent.com/1011391/227623190-b121c229-8a37-491a-b4b3-258048284f34.png">

Discussion on a standard is here, but i should move it to github: https://www.notion.so/alexatallah/RFC-LLM-API-Standard-c8f15d24bd2f4ab98b656f08cdc1c4fb?pvs=4